### PR TITLE
Qiling Backend Stub Implementation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# ignore these files / directories in build context
+ghidra-project/
+build_and_run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,16 @@ RUN cd Ghidrathon-2.0.1 && gradle -PGHIDRA_INSTALL_DIR=$GHIDRA_INSTALL_DIR -PPYT
 RUN git clone -b 1.4.5 https://github.com/qilingframework/qiling.git
 RUN cd qiling && git submodule update --init --recursive && python3 -m pip install .
 
+# install CoreReveal
+WORKDIR /tmp/corereveal
+RUN python3 -m pip install --upgrade pip pylint
+COPY . .
+RUN python3 -m pip install .
+RUN python3 -m pylint corereveal
+
 # move Ghidrathon extensions and our custom scripts into Ghidra installation (for easy access)
 RUN mv /opt/Ghidrathon-2.0.1/dist/*.zip $GHIDRA_INSTALL_DIR/Extensions/Ghidra/
-COPY CoreReveal/CoreReveal.py $GHIDRA_INSTALL_DIR/Ghidra/Features/Python/ghidra_scripts/
+COPY scripts/CoreReveal.py $GHIDRA_INSTALL_DIR/Ghidra/Features/Python/ghidra_scripts/
 
 # drop into an interactive shell
 WORKDIR /root/workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = [
+  "hatchling",
+  "qiling",
+  "pylint"
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "corereveal"
+version = "0.0.1"
+authors = [
+  { name="Daniel M. Sahu", email="dsahu@fake.com" },
+  { name="Brandon Wong", email="todo@fake.com" },
+]
+description = "CoreReveal - Qiling emulation embedded in Ghidra."
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/danielmohansahu/corereveal"
+"Bug Tracker" = "https://github.com/danielmohansahu/corereveal/issues"
+
+[tool.pylint.messages_control]
+disable = [
+  # ignore CONVENTION / REFACTORING / WARNING checks
+  "C",
+  "R",
+  # @TODO re-enable some of these!
+  "bad-indentation",
+  "unused-argument",
+  "unused-import"
+]

--- a/scripts/CoreReveal.py
+++ b/scripts/CoreReveal.py
@@ -14,11 +14,11 @@ them all run `dir(builtins)`.
 # STL
 import sys
 
+# CoreReveal
+from corereveal.qiling_interface import QilingInterface
+
 # sanity check we're using Python3 (via Ghidrathon)
 assert sys.version_info > (3,0), "Incorrect Python version; do you have Ghidrathon installed?"
-
-# Qiling
-from qiling import Qiling
 
 if __name__ == "__main__":
     popup("Hello, World!")

--- a/src/corereveal/qiling_interface.py
+++ b/src/corereveal/qiling_interface.py
@@ -1,0 +1,51 @@
+""" QilingInterface - Backend class wrapping Qiling emulator.
+
+This file contains the implementation of the QilingInterface class
+which accomplishes the following functions:
+ - binary / executable emulation,
+ - STDIN / STDOUT / CLI argument passthrough,
+ - packaging of emulation results, including:
+   - addresses of basic blocks encountered during emulation,
+   - values of static (.bss) variables,
+   - arguments to POSIX calls (read, write, ...?)
+"""
+
+# STL
+from typing import Callable
+from dataclasses import dataclass
+
+# Qiling
+from qiling import Qiling
+
+
+
+
+# data structure of results from Qiling
+@dataclass
+class EmulationResults:
+  blocks:           list = field(default_factory=list) # basic blocks encountered [(address, name)]
+  static_variables: dict = field(default_factory=dict) # static variable values {variable : [values]}
+  posix_calls:      dict = field(default_factory=dict) # arguments to posix calls {call : [(arg1, arg2, ..., argN)] }
+
+class QilingInterface:
+  """ Core Qiling Interface Class """
+  
+  def __init__(self, program: str, metadata: str):
+    """ Setup and initialization of underlying Qiling environment.
+
+    Args:
+      filename:   Full path to the program to execute.
+      metadata:   Executable metadata (architecture, endianness, etc.).
+    """
+    # I am a stub.
+  
+  def emulate(self, args: str, stdin_cb: Callable, stdout_cb: Callable) -> EmulationResults:
+    """ Perform emulation and return the top-level execution trace / metadata.
+
+    Args:
+      args:       Command line arguments in string format to pass to program.
+      stdin_cb:   Callback executed when STDIN is requested.
+      stdout_cb:  Callback executed when STDOUT is produced.
+    """
+    # I am a stub.
+    return EmulationResults()

--- a/src/corereveal/qiling_interface.py
+++ b/src/corereveal/qiling_interface.py
@@ -12,20 +12,20 @@ which accomplishes the following functions:
 
 # STL
 from typing import Callable
-from dataclasses import dataclass
+import dataclasses
 
 # Qiling
 from qiling import Qiling
 
-
-
-
 # data structure of results from Qiling
-@dataclass
+@dataclasses.dataclass
 class EmulationResults:
-  blocks:           list = field(default_factory=list) # basic blocks encountered [(address, name)]
-  static_variables: dict = field(default_factory=dict) # static variable values {variable : [values]}
-  posix_calls:      dict = field(default_factory=dict) # arguments to posix calls {call : [(arg1, arg2, ..., argN)] }
+  # basic blocks encountered [(address, name)]
+  blocks:           list = dataclasses.field(default_factory=list)
+  # static variable values {variable : [values]}
+  static_variables: dict = dataclasses.field(default_factory=dict)
+  # arguments to posix calls {call : [(arg1, arg2, ..., argN)] }
+  posix_calls:      dict = dataclasses.field(default_factory=dict)
 
 class QilingInterface:
   """ Core Qiling Interface Class """


### PR DESCRIPTION
This PR accomplishes the following:

1. Decouple the Ghidra visualization frontend (`CoreReveal.py`) from the Qiling emulation backend. This decoupling allows us to set up tests to validate, e.g., emulation results without Ghidra dependencies.
2. A stub implementation of the expected API between Ghidra and the backend system. This is subject to change but provides a common starting point for front- and back-end concurrent development.
