### PR TITLE
Ghidra Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+REPOSITORY UNDER DEVELOPMENT!
+
 # corereveal
 Leveraging [Qiling](https://qiling.io/) and [Ghidra](https://ghidra-sre.org/) for binary analysis.
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ python3 -m pip install rocker
 
 **Instructions:**
 1. Build Docker image and drop into an interactive container via `./build_and_run.sh`
-2. Run Ghidra via `ghidraRun` and install Ghidrathon extension. Restart.
-3. (optional, per-project): Run Ghidra via `ghidraRun` and disable native (Jython) Python support. Restart.
-4. (optional): `docker commit` the modified container so you don't need to repeat these steps on every restart.
+2. Start Ghidra via `ghidraRun`
+3. (one-time-only) install Ghidrathon extension; restart
+4. (one-time-only) disable native (Jython) Python support; restart
+5. Open a project and begin analysis
 
 Initial Configuration | Script Execution
 --- | ---

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -10,4 +10,4 @@ IMAGE=ghidra-development:latest
 docker build -t $IMAGE $SCRIPTPATH/
 
 # drop into a container
-rocker --x11 --volume $SCRIPTPATH:/root/workspace -- $IMAGE byobu
+rocker --x11 --volume $SCRIPTPATH/ghidra-project/.ghidra:/root/.ghidra --volume $SCRIPTPATH:/root/workspace -- $IMAGE byobu

--- a/scripts/CoreReveal.py
+++ b/scripts/CoreReveal.py
@@ -1,3 +1,4 @@
+# CoreReveal - Qiling based program flow emulation and visualization.
 """CoreReveal - Ghidrathon based Ghidra script that executes and analyzes a Qiling emulation.
 
 CoreReveal performs emulation via Qiling and analyzes the program flow.
@@ -14,11 +15,58 @@ them all run `dir(builtins)`.
 # STL
 import sys
 
-# CoreReveal
-from corereveal.qiling_interface import QilingInterface
-
 # sanity check we're using Python3 (via Ghidrathon)
 assert sys.version_info > (3,0), "Incorrect Python version; do you have Ghidrathon installed?"
 
+# Ghidra
+from ghidra.program.flatapi import FlatProgramAPI
+
+# CoreReveal
+from corereveal.qiling_interface import QilingInterface
+
+def annotate_bss(api, variables: dict):
+    """ Add annotations to the current program detailing BSS values. """
+    # @TODO!
+
+def annotate_posix_calls(api, posix_calls: dict):
+    """ Add annotations to the current program detailing POSIX call arguments. """
+    # @TODO!
+
+def color_function_graph(api, blocks: list):
+    """ Highlight the blocks encountered and display the Function Graph. """
+    # @TODO!
+
 if __name__ == "__main__":
-    popup("Hello, World!")
+    # sanity check
+    if not getState().getCurrentProgram():
+        popup("No program selected; unable to emulate.")
+        sys.exit(1)
+    
+    # construct basic ghidra program objects
+    program = getState().getCurrentProgram()
+    ghidra_api = FlatProgramAPI(program)
+
+    # construct core interface class
+    # @TODO determine which program details (e.g. endianess) we need to / should send
+    interface = QilingInterface(program.getExecutablePath(), program.getLanguage().toString())
+
+    # prompt for user input
+    cli_args = askString(f"Executing {program.toString()}", "Command Line Arguments")
+
+    # perform emulation
+    # @TODO update system monitor with progress bar
+    res = interface.emulate(
+        cli_args,
+        lambda prompt: askString("STDIN", prompt),
+        lambda output: popup(output)
+    )
+
+    # handle failure conditions
+    if not res:
+       popup("Emulation failed!")
+       sys.exit(2)
+
+    # format output and visualize
+    annotate_bss(ghidra_api, res.static_variables)
+    annotate_posix_calls(ghidra_api, res.posix_calls)
+    color_function_graph(ghidra_api, res.blocks)

--- a/scripts/CoreReveal.py
+++ b/scripts/CoreReveal.py
@@ -20,9 +20,18 @@ assert sys.version_info > (3,0), "Incorrect Python version; do you have Ghidrath
 
 # Ghidra
 from ghidra.program.flatapi import FlatProgramAPI
+from ghidra.program.model.block import BasicBlockModel
+from ghidra.util.task import ConsoleTaskMonitor
 
 # CoreReveal
 from corereveal.qiling_interface import QilingInterface
+
+########## TEMPORARY TESTING - @TODO REMOVE ##########
+from corereveal.mock_qiling_interface import MockQilingInterface
+######################################################
+
+# Hardcoded global variables - @TODO remove the need for this
+FUNCTION = "main"
 
 def annotate_bss(api, variables: dict):
     """ Add annotations to the current program detailing BSS values. """
@@ -44,11 +53,23 @@ if __name__ == "__main__":
     
     # construct basic ghidra program objects
     program = getState().getCurrentProgram()
+    block_model = BasicBlockModel(program)
     ghidra_api = FlatProgramAPI(program)
+    monitor = ConsoleTaskMonitor()
+    main_function = getGlobalFunctions(FUNCTION)[0]
 
     # construct core interface class
     # @TODO determine which program details (e.g. endianess) we need to / should send
-    interface = QilingInterface(program.getExecutablePath(), program.getLanguage().toString())
+    # interface = QilingInterface(program.getExecutablePath(), program.getLanguage().toString())
+
+    ########## TEMPORARY TESTING - @TODO REMOVE ##########
+    interface = MockQilingInterface(
+        program.getExecutablePath(),
+        program.getLanguage().toString(),
+        None,
+        None
+    )
+    ######################################################
 
     # prompt for user input
     cli_args = askString(f"Executing {program.toString()}", "Command Line Arguments")

--- a/scripts/CoreReveal.py
+++ b/scripts/CoreReveal.py
@@ -22,6 +22,7 @@ assert sys.version_info > (3,0), "Incorrect Python version; do you have Ghidrath
 from ghidra.program.flatapi import FlatProgramAPI
 from ghidra.util.task import ConsoleTaskMonitor
 from ghidra.program.model.address import AddressSet
+from ghidra.app.util import CodeUnitInfo
 from java.awt import Color
 
 # CoreReveal
@@ -34,22 +35,28 @@ from corereveal.mock_qiling_interface import MockQilingInterface
 # Hardcoded global variables
 BACKGROUND_COLOR = Color.PINK
 
-def annotate_bss(api, variables: dict):
+def annotate_bss(api, program, variables: dict):
     """ Add annotations to the current program detailing BSS values. """
     # @TODO!
 
-def annotate_posix_calls(api, posix_calls: dict):
+def annotate_posix_calls(api, program, posix_calls: dict):
     """ Add annotations to the current program detailing POSIX call arguments. """
     # @TODO!
 
 def color_function_graph(api, program, blocks: list):
     """ Highlight the blocks encountered and display the Function Graph. """
+    # get program listing for commenting
+    listing = program.getListing()
+
     # convert list of address strings to address objects
     start = program.getMinAddress()
     for string in blocks:
         if address := start.getAddress(string):
             # address found; set background
             setBackgroundColor(address, BACKGROUND_COLOR)
+            # add a comment too, if this is a valid CodeUnit
+            if code_unit := listing.getCodeUnitAt(address):
+                code_unit.setComment(code_unit.PLATE_COMMENT, f"Background color set by CoreReveal")
         else:
             popup(f"Skipping invalid address {string}!")
 
@@ -97,8 +104,8 @@ if __name__ == "__main__":
     print(f"Emulation succeeded; post-processing...")
 
     # format output and visualize
-    annotate_bss(ghidra_api, res.static_variables)
-    annotate_posix_calls(ghidra_api, res.posix_calls)
+    annotate_bss(ghidra_api, program, res.static_variables)
+    annotate_posix_calls(ghidra_api, program, res.posix_calls)
     color_function_graph(ghidra_api, program, res.block_addresses)
 
     print(f"Success!")

--- a/src/corereveal/mock_qiling_interface.py
+++ b/src/corereveal/mock_qiling_interface.py
@@ -1,0 +1,60 @@
+""" Mock implementation of QilingInterface.
+
+This class is a dummy implementation of the QilingInterface
+class for testing and development.
+"""
+
+# STL
+import time
+import random
+from typing import Callable
+
+# CoreReveal
+from .qiling_interface import QilingInterface, EmulationResults
+
+class MockQilingInterface:
+    """ Mock QilingInterface class, for testing and development. """
+    def __init__(self, program, metadata, blocks, static_variables):
+        """ Mock initialization takes the same arguments as the core class
+            as well as some Ghidra-supplied program info.
+        """
+        self.program  = program
+        self.metadata = metadata
+        self.blocks = blocks
+        self.static_variables = static_variables
+
+    def emulate(self, args: str, stdin_cb: Callable, stdout_cb: Callable) -> EmulationResults:
+        """ Simulate emulation. """
+
+        # determine duration
+        duration = random.random() * 10
+        
+        # 50/50 chance of prompting for user input right off the bat
+        if random.random() > 0.5:
+            stdin_cb("How are you feeling?")
+        stdout_cb("I understand.")
+        
+        # loop until desired time is up
+        st = time.time()
+        while (time.time() - st < duration):
+            # maybe we need more user input
+            if random.random() > 0.9:
+                stdin_cb("Please provide additional input")
+            
+            # it's more likely that we just spam 
+            if random.random() > 0.5:
+                stdout_cb("SPAM!")
+            
+            # sleep
+            time.sleep(random.random())
+
+        # there's a small chance emulation failed
+        if random.random() < 0.2:
+            stdout_cb("SEGFAULT")
+            return None
+        
+        # otherwise, populate random results
+        results = EmulationResults()
+
+        # @TODO populate
+        return results

--- a/src/corereveal/mock_qiling_interface.py
+++ b/src/corereveal/mock_qiling_interface.py
@@ -12,15 +12,21 @@ from typing import Callable
 # CoreReveal
 from .qiling_interface import QilingInterface, EmulationResults
 
+def generate_random_addresses(start: str, end_offset: int = 2048, count: int = 150):
+    """ Generate 'count' random addresses in the range ['start', 'start' + 'end_offset'] """
+    begin = int(start, 16)
+    end = begin + end_offset
+    return [hex(address) for address in random.choices(range(begin, end), k=count)]
+
 class MockQilingInterface:
     """ Mock QilingInterface class, for testing and development. """
-    def __init__(self, program, metadata, blocks, static_variables):
+    def __init__(self, program, metadata, start_address, static_variables):
         """ Mock initialization takes the same arguments as the core class
             as well as some Ghidra-supplied program info.
         """
         self.program  = program
         self.metadata = metadata
-        self.blocks = blocks
+        self.start_address = start_address
         self.static_variables = static_variables
 
     def emulate(self, args: str, stdin_cb: Callable, stdout_cb: Callable) -> EmulationResults:
@@ -28,7 +34,7 @@ class MockQilingInterface:
 
         # determine duration
         duration = random.random() * 10
-        
+
         # 50/50 chance of prompting for user input right off the bat
         if random.random() > 0.5:
             stdin_cb("How are you feeling?")
@@ -56,5 +62,8 @@ class MockQilingInterface:
         # otherwise, populate random results
         results = EmulationResults()
 
-        # @TODO populate
+        # get random address after our start address
+        results.block_addresses = generate_random_addresses(self.start_address)
+
+        # @TODO populate syscall information and comments
         return results

--- a/src/corereveal/mock_qiling_interface.py
+++ b/src/corereveal/mock_qiling_interface.py
@@ -48,14 +48,14 @@ class MockQilingInterface:
                 stdin_cb("Please provide additional input")
             
             # it's more likely that we just spam 
-            if random.random() > 0.5:
+            if random.random() > 0.75:
                 stdout_cb("SPAM!")
             
             # sleep
             time.sleep(random.random())
 
         # there's a small chance emulation failed
-        if random.random() < 0.2:
+        if random.random() < 0.05:
             stdout_cb("SEGFAULT")
             return None
         

--- a/src/corereveal/qiling_interface.py
+++ b/src/corereveal/qiling_interface.py
@@ -21,7 +21,7 @@ from qiling import Qiling
 @dataclasses.dataclass
 class EmulationResults:
   # basic blocks encountered [(address, name)]
-  blocks:           list = dataclasses.field(default_factory=list)
+  block_addresses:  list = dataclasses.field(default_factory=list)
   # static variable values {variable : [values]}
   static_variables: dict = dataclasses.field(default_factory=dict)
   # arguments to posix calls {call : [(arg1, arg2, ..., argN)] }


### PR DESCRIPTION
This PR implements the project's Front End: visualization of the Qiling Emulation results in Ghidra.

There are basically three tasks:
- [ ] Display static variable values (`.bss`) as comments.
- [ ] Display arguments to supported POSIX calls (`read`, `write`, ...) as comments.
- [ ] Launch existing Function Graph plugin and highlight traversed Basic Blocks. 